### PR TITLE
Fixes to 90 day account expiry for admins:

### DIFF
--- a/Admin/AdminSessionModule.php
+++ b/Admin/AdminSessionModule.php
@@ -20,6 +20,19 @@ require_once 'Swat/SwatString.php';
  */
 class AdminSessionModule extends SiteSessionModule
 {
+	// {{{ class constants
+
+	/**
+	 * How many days an admin user account is considered active
+	 *
+	 * If an account has no sign-in activity for this many days, it will be
+	 * prevented from signing into the admin.
+	 *
+	 * @see AdminSessionModule::isActiveUser()
+	 */
+	const ACCOUNT_EXPIRY_DAYS = 90;
+
+	// }}}
 	// {{{ protected properties
 
 	/**
@@ -337,6 +350,10 @@ class AdminSessionModule extends SiteSessionModule
 	 * days from the creation of the account if the user has never logged in.
 	 *
 	 * @param AdminUser $user_id the user to record login history for.
+	 *
+	 * @return boolean
+	 *
+	 * @see AdminSessionModule::ACCOUNT_EXPIRY_DAYS
 	 */
 	protected function isActiveUser(AdminUser $user)
 	{
@@ -351,7 +368,7 @@ class AdminSessionModule extends SiteSessionModule
 		}
 
 		$threshold = new SwatDate();
-		$threshold->subtractDays(90);
+		$threshold->subtractDays(self::ACCOUNT_EXPIRY_DAYS);
 		if ($comparison_date instanceof SwatDate &&
 			$comparison_date->after($threshold)) {
 			$active_user = true;

--- a/Admin/AdminSessionModule.php
+++ b/Admin/AdminSessionModule.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'Admin/dataobjects/AdminUser.php';
+require_once 'Admin/dataobjects/AdminUserHistory.php';
 require_once 'Admin/dataobjects/AdminUserWrapper.php';
 require_once 'Admin/exceptions/AdminException.php';
 require_once 'Site/SiteSessionModule.php';
@@ -341,16 +342,18 @@ class AdminSessionModule extends SiteSessionModule
 	{
 		$active_user = false;
 
-		$threshold = new SwatDate();
-		$threshold->subtractDays(90);
+		$comparison_date = null;
 
-		if ($user->createdate instanceof SwatDate) {
+		if ($user->most_recent_history instanceof AdminUserHistory) {
+			$comparison_date = $user->most_recent_history->login_date;
+		} elseif ($user->createdate instanceof SwatDate) {
 			$comparison_date = $user->createdate;
-		} elseif ($user->most_recent_login instanceof AdminUserHistory) {
-			$comparison_date = $user->most_recent_login->login_date;
 		}
 
-		if ($comparison_date->after($threshold)) {
+		$threshold = new SwatDate();
+		$threshold->subtractDays(90);
+		if ($comparison_date instanceof SwatDate &&
+			$comparison_date->after($threshold)) {
 			$active_user = true;
 		}
 

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -382,7 +382,7 @@ class AdminUser extends SwatDBDataObject
 	}
 
 	// }}}
-	// {{{ protected function loadMostRecentLogin()
+	// {{{ protected function loadMostRecentHistory()
 
 	/**
 	 * Gets most recent login history for this user
@@ -395,7 +395,7 @@ class AdminUser extends SwatDBDataObject
 	 *
 	 * @see AdminUser::setInstance()
 	 */
-	protected function loadMostRecentLogin()
+	protected function loadMostRecentHistory()
 	{
 		$instance_id = null;
 
@@ -406,14 +406,17 @@ class AdminUser extends SwatDBDataObject
 		$sql = sprintf(
 			'select * from AdminUserHistory
 			where usernum = %s and instance %s %s
-			order by createdate desc',
+			order by login_date desc',
 			$this->db->quote($this->id, 'integer'),
 			SwatDB::equalityOperator($instance_id),
 			$this->db->quote($instance_id, 'integer')
 		);
 
-		$this->db->setLimit(1);
-		return SwatDB::query($this->db, $sql, 'AdminUserHistoryWrapper');
+		return SwatDB::query(
+			$this->db,
+			$sql,
+			'AdminUserHistoryWrapper'
+		)->getFirst();
 	}
 
 	// }}}


### PR DESCRIPTION
- rename method loadMostRecentHistory to match loadHistory
- make loadMostRecentHistory return a single object instead of a wrapper
- fix SQL in loadMostRecentHistory
- fix initilization of comparison date in isActiveUser
- fix potential error on null comparison date in isActiveUser
- move constant value to a defined constant
